### PR TITLE
Add TTL support and persistence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# AGENTS
+
+## Repository Notes
+- TTL support is implemented via `database/expire.go` and `DB.expires` (unix milliseconds).
+- Lazy expiration runs in `DB.GetEntity` and `execKeys`; expired keys are removed on access.
+- Any write clears TTL via `DB.Put*`/`Remove` plus explicit clears in hash write commands.
+- AOF persistence for TTL always uses absolute `PEXPIREAT`; `SET` with EX/PX and `SETEX` emit `SET` + `PEXPIREAT`.
+- Cluster routing adds TTL commands (`expire`, `pexpire`, `expireat`, `pexpireat`, `ttl`, `pttl`, `persist`, `setex`).

--- a/README.md
+++ b/README.md
@@ -70,11 +70,19 @@ TYPE key                       # 获取键的数据类型
 RENAME key newkey              # 重命名键
 RENAMENX key newkey            # 仅当新键不存在时重命名
 KEYS pattern                   # 查找匹配模式的键
+EXPIRE key seconds             # 设置过期时间（秒）
+PEXPIRE key milliseconds       # 设置过期时间（毫秒）
+EXPIREAT key timestamp         # 设置过期时间（秒时间戳）
+PEXPIREAT key milliseconds-timestamp # 设置过期时间（毫秒时间戳）
+TTL key                        # 获取剩余过期时间（秒）
+PTTL key                       # 获取剩余过期时间（毫秒）
+PERSIST key                    # 移除过期时间
 ```
 
 #### 📝 字符串操作
 ```bash
-SET key value                  # 设置键值对
+SET key value [EX seconds|PX milliseconds]  # 设置键值对并可选过期
+SETEX key seconds value        # 设置键值对并指定秒级过期
 GET key                        # 获取键的值
 SETNX key value               # 仅当键不存在时设置
 GETSET key value              # 设置新值并返回旧值

--- a/cluster/router.go
+++ b/cluster/router.go
@@ -15,6 +15,14 @@ func makeRouter() map[string]CmdFunc {
 	routerMap["get"] = defaultFunc    // get key
 	routerMap["setnx"] = defaultFunc  // setnx key
 	routerMap["getset"] = defaultFunc // getset key
+	routerMap["setex"] = defaultFunc  // setex key
+	routerMap["expire"] = defaultFunc
+	routerMap["pexpire"] = defaultFunc
+	routerMap["expireat"] = defaultFunc
+	routerMap["pexpireat"] = defaultFunc
+	routerMap["ttl"] = defaultFunc
+	routerMap["pttl"] = defaultFunc
+	routerMap["persist"] = defaultFunc
 
 	routerMap["ping"] = pingFunc     // ping command
 	routerMap["rename"] = renameFunc // rename key

--- a/database/db.go
+++ b/database/db.go
@@ -10,6 +10,7 @@ import (
 	"redigo/resp/reply"
 	"strings"
 	"sync"
+	"time"
 )
 
 // KeyLockManager manages locks for individual keys
@@ -64,6 +65,7 @@ func (klm *KeyLockManager) CleanupLock(key string) {
 type DB struct {
 	index   int
 	data    dict.Dict
+	expires dict.Dict
 	addAof  func(CmdLine)
 	lockMgr *KeyLockManager
 }
@@ -71,8 +73,9 @@ type DB struct {
 // MakeDB creates a new DB instance
 func MakeDB() *DB {
 	return &DB{
-		index: 0,
-		data:  dict.MakeSyncDict(),
+		index:   0,
+		data:    dict.MakeSyncDict(),
+		expires: dict.MakeSyncDict(),
 		addAof: func(line CmdLine) {
 			// No-op by default,
 			// can be overridden by the database instance
@@ -122,10 +125,50 @@ func ValidateArity(arity int, args [][]byte) bool {
 	}
 }
 
+// SetExpire sets the expiration time for a key (unix milliseconds).
+func (db *DB) SetExpire(key string, expireAt int64) {
+	db.expires.Put(key, expireAt)
+}
+
+// GetExpire retrieves the expiration time for a key.
+func (db *DB) GetExpire(key string) (int64, bool) {
+	raw, ok := db.expires.Get(key)
+	if !ok {
+		return 0, false
+	}
+	expireAt, ok := raw.(int64)
+	if !ok {
+		return 0, false
+	}
+	return expireAt, true
+}
+
+// ClearExpire removes the expiration for a key.
+func (db *DB) ClearExpire(key string) {
+	db.expires.Remove(key)
+}
+
+// isExpired checks if the key is expired and deletes it if needed.
+func (db *DB) isExpired(key string) bool {
+	expireAt, ok := db.GetExpire(key)
+	if !ok {
+		return false
+	}
+	if time.Now().UnixMilli() >= expireAt {
+		db.Remove(key)
+		return true
+	}
+	return false
+}
+
 // GetEntity returns DataEntity bind to the given key
 func (db *DB) GetEntity(key string) (*database.DataEntity, bool) {
+	if db.isExpired(key) {
+		return nil, false
+	}
 	raw, ok := db.data.Get(key)
 	if !ok {
+		db.ClearExpire(key)
 		return nil, false
 	}
 	entity, _ := raw.(*database.DataEntity)
@@ -134,21 +177,32 @@ func (db *DB) GetEntity(key string) (*database.DataEntity, bool) {
 
 // PutEntity stores the given DataEntity in the database
 func (db *DB) PutEntity(key string, entity *database.DataEntity) int {
-	return db.data.Put(key, entity)
+	result := db.data.Put(key, entity)
+	db.ClearExpire(key)
+	return result
 }
 
 // PutIfExists edit the given DataEntity in the database
 func (db *DB) PutIfExists(key string, entity *database.DataEntity) int {
-	return db.data.PutIfExists(key, entity)
+	result := db.data.PutIfExists(key, entity)
+	if result > 0 {
+		db.ClearExpire(key)
+	}
+	return result
 }
 
 // PutIfAbsent stores the given DataEntity in the database if it doesn't already exist
 func (db *DB) PutIfAbsent(key string, entity *database.DataEntity) int {
-	return db.data.PutIfAbsent(key, entity)
+	result := db.data.PutIfAbsent(key, entity)
+	if result > 0 {
+		db.ClearExpire(key)
+	}
+	return result
 }
 
 // Remove deletes the DataEntity associated with the given key from the database
 func (db *DB) Remove(key string) int {
+	db.ClearExpire(key)
 	result := db.data.Remove(key)
 	// Clean up the lock for the deleted key to prevent memory leaks
 	if result > 0 {
@@ -236,6 +290,7 @@ func getAsZSet(db *DB, key string) (zset.ZSet, bool) {
 func (db *DB) Removes(keys ...string) int {
 	deleted := 0
 	for _, key := range keys {
+		db.ClearExpire(key)
 		result := db.data.Remove(key)
 		if result > 0 {
 			// Clean up the lock for the deleted key to prevent memory leaks
@@ -249,6 +304,7 @@ func (db *DB) Removes(keys ...string) int {
 // Flush clears the database by removing all DataEntity objects
 func (db *DB) Flush() {
 	db.data.Clear()
+	db.expires.Clear()
 	// Clear all locks when flushing the database
 	db.lockMgr.locks = sync.Map{}
 }

--- a/database/expire.go
+++ b/database/expire.go
@@ -1,0 +1,125 @@
+package database
+
+import (
+	"redigo/interface/resp"
+	"redigo/lib/utils"
+	"redigo/resp/reply"
+	"strconv"
+	"time"
+)
+
+func parseExpireArg(arg []byte) (int64, resp.Reply) {
+	value, err := strconv.ParseInt(string(arg), 10, 64)
+	if err != nil {
+		return 0, reply.MakeStandardErrorReply("ERR value is not an integer or out of range")
+	}
+	return value, nil
+}
+
+func setExpireAt(db *DB, key string, expireAt int64) resp.Reply {
+	if _, ok := db.GetEntity(key); !ok {
+		return reply.MakeIntReply(0)
+	}
+	if expireAt <= time.Now().UnixMilli() {
+		db.Remove(key)
+	} else {
+		db.SetExpire(key, expireAt)
+	}
+	db.addAof(utils.ToCmdLineWithName("PEXPIREAT", []byte(key), []byte(strconv.FormatInt(expireAt, 10))))
+	return reply.MakeIntReply(1)
+}
+
+// execExpire handles EXPIRE key seconds
+func execExpire(db *DB, args [][]byte) resp.Reply {
+	key := string(args[0])
+	seconds, errReply := parseExpireArg(args[1])
+	if errReply != nil {
+		return errReply
+	}
+	expireAt := time.Now().UnixMilli() + seconds*1000
+	return setExpireAt(db, key, expireAt)
+}
+
+// execPExpire handles PEXPIRE key milliseconds
+func execPExpire(db *DB, args [][]byte) resp.Reply {
+	key := string(args[0])
+	milliseconds, errReply := parseExpireArg(args[1])
+	if errReply != nil {
+		return errReply
+	}
+	expireAt := time.Now().UnixMilli() + milliseconds
+	return setExpireAt(db, key, expireAt)
+}
+
+// execExpireAt handles EXPIREAT key timestamp (seconds)
+func execExpireAt(db *DB, args [][]byte) resp.Reply {
+	key := string(args[0])
+	seconds, errReply := parseExpireArg(args[1])
+	if errReply != nil {
+		return errReply
+	}
+	expireAt := seconds * 1000
+	return setExpireAt(db, key, expireAt)
+}
+
+// execPExpireAt handles PEXPIREAT key timestamp (milliseconds)
+func execPExpireAt(db *DB, args [][]byte) resp.Reply {
+	key := string(args[0])
+	milliseconds, errReply := parseExpireArg(args[1])
+	if errReply != nil {
+		return errReply
+	}
+	return setExpireAt(db, key, milliseconds)
+}
+
+func ttlWithUnit(db *DB, key string, unit int64) resp.Reply {
+	if _, ok := db.GetEntity(key); !ok {
+		return reply.MakeIntReply(-2)
+	}
+	expireAt, ok := db.GetExpire(key)
+	if !ok {
+		return reply.MakeIntReply(-1)
+	}
+	remaining := expireAt - time.Now().UnixMilli()
+	if remaining <= 0 {
+		db.Remove(key)
+		return reply.MakeIntReply(-2)
+	}
+	return reply.MakeIntReply(remaining / unit)
+}
+
+// execTTL handles TTL key
+func execTTL(db *DB, args [][]byte) resp.Reply {
+	key := string(args[0])
+	return ttlWithUnit(db, key, 1000)
+}
+
+// execPTTL handles PTTL key
+func execPTTL(db *DB, args [][]byte) resp.Reply {
+	key := string(args[0])
+	return ttlWithUnit(db, key, 1)
+}
+
+// execPersist handles PERSIST key
+func execPersist(db *DB, args [][]byte) resp.Reply {
+	key := string(args[0])
+	if _, ok := db.GetEntity(key); !ok {
+		return reply.MakeIntReply(0)
+	}
+	if _, ok := db.GetExpire(key); !ok {
+		return reply.MakeIntReply(0)
+	}
+	db.ClearExpire(key)
+	db.addAof(utils.ToCmdLineWithName("PERSIST", args...))
+	return reply.MakeIntReply(1)
+}
+
+func init() {
+	RegisterCommand("EXPIRE", execExpire, 3)
+	RegisterCommand("PEXPIRE", execPExpire, 3)
+	RegisterCommand("EXPIREAT", execExpireAt, 3)
+	RegisterCommand("PEXPIREAT", execPExpireAt, 3)
+	RegisterCommand("TTL", execTTL, 2)
+	RegisterCommand("PTTL", execPTTL, 2)
+	RegisterCommand("PERSIST", execPersist, 2)
+}

--- a/database/hash.go
+++ b/database/hash.go
@@ -17,6 +17,7 @@ func execHSet(db *DB, args [][]byte) resp.Reply {
 	// Use key-level locking to prevent concurrent modification of the same hash
 	db.WithKeyLock(key, func() {
 		hashObj, _ := db.getOrCreateHash(key)
+		db.ClearExpire(key)
 		res := hashObj.Set(field, value)
 
 		db.addAof(utils.ToCmdLineWithName("HSET", args...))
@@ -81,11 +82,13 @@ func execHDel(db *DB, args [][]byte) resp.Reply {
 			deleted += hash.Delete(string(field))
 		}
 
-		if hash.Len() == 0 {
-			db.Remove(key)
-		}
-
 		if deleted > 0 {
+			if hash.Len() == 0 {
+				db.Remove(key)
+			} else {
+				db.ClearExpire(key)
+			}
+
 			db.addAof(utils.ToCmdLineWithName("hdel", args...))
 		}
 
@@ -234,6 +237,7 @@ func execHMSet(db *DB, args [][]byte) resp.Reply {
 	// Use key-level locking to prevent concurrent modification of the same hash
 	db.WithKeyLock(key, func() {
 		hash, _ := db.getOrCreateHash(key)
+		db.ClearExpire(key)
 
 		for i := 1; i < len(args); i += 2 {
 			field := string(args[i])
@@ -282,6 +286,7 @@ func execHSetNX(db *DB, args [][]byte) resp.Reply {
 			return
 		}
 
+		db.ClearExpire(key)
 		hash.Set(field, value)
 
 		db.addAof(utils.ToCmdLineWithName("HSETNX", args...))

--- a/database/keys.go
+++ b/database/keys.go
@@ -102,6 +102,9 @@ func execKeys(db *DB, args [][]byte) resp.Reply {
 	pattern := wildcard.CompilePattern(string(args[0]))
 	result := make([][]byte, 0) // Store all matching keys
 	db.data.ForEach(func(key string, val interface{}) bool {
+		if db.isExpired(key) {
+			return true
+		}
 		if pattern.IsMatch(key) {
 			result = append(result, []byte(key))
 		}

--- a/database/strings.go
+++ b/database/strings.go
@@ -5,6 +5,9 @@ import (
 	"redigo/interface/resp"
 	"redigo/lib/utils"
 	"redigo/resp/reply"
+	"strconv"
+	"strings"
+	"time"
 )
 
 // execGet retrieves the value associated with the specified key from the database.
@@ -21,11 +24,70 @@ func execGet(db *DB, args [][]byte) resp.Reply {
 func execSet(db *DB, args [][]byte) resp.Reply {
 	key := string(args[0])
 	value := args[1]
+
+	var expireAt int64
+	hasExpire := false
+	if len(args) > 2 {
+		if (len(args)-2)%2 != 0 {
+			return reply.MakeStandardErrorReply("ERR syntax error")
+		}
+		for i := 2; i < len(args); i += 2 {
+			option := strings.ToLower(string(args[i]))
+			if option != "ex" && option != "px" {
+				return reply.MakeStandardErrorReply("ERR syntax error")
+			}
+			if hasExpire {
+				return reply.MakeStandardErrorReply("ERR syntax error")
+			}
+			ttlValue, err := strconv.ParseInt(string(args[i+1]), 10, 64)
+			if err != nil {
+				return reply.MakeStandardErrorReply("ERR value is not an integer or out of range")
+			}
+			if ttlValue <= 0 {
+				return reply.MakeStandardErrorReply("ERR invalid expire time in set")
+			}
+			if option == "ex" {
+				expireAt = time.Now().UnixMilli() + ttlValue*1000
+			} else {
+				expireAt = time.Now().UnixMilli() + ttlValue
+			}
+			hasExpire = true
+		}
+	}
+
 	entity := &database.DataEntity{
 		Data: value,
 	}
 	db.PutEntity(key, entity)
-	db.addAof(utils.ToCmdLineWithName("SET", args...))
+	db.addAof(utils.ToCmdLineWithName("SET", []byte(key), value))
+	if hasExpire {
+		db.SetExpire(key, expireAt)
+		db.addAof(utils.ToCmdLineWithName("PEXPIREAT", []byte(key), []byte(strconv.FormatInt(expireAt, 10))))
+	}
+	return reply.MakeOKReply()
+}
+
+// execSetEX stores the specified key-value pair with expiration time in seconds.
+func execSetEX(db *DB, args [][]byte) resp.Reply {
+	key := string(args[0])
+	seconds, err := strconv.ParseInt(string(args[1]), 10, 64)
+	if err != nil {
+		return reply.MakeStandardErrorReply("ERR value is not an integer or out of range")
+	}
+	if seconds <= 0 {
+		return reply.MakeStandardErrorReply("ERR invalid expire time in setex")
+	}
+	value := args[2]
+
+	entity := &database.DataEntity{
+		Data: value,
+	}
+	db.PutEntity(key, entity)
+	expireAt := time.Now().UnixMilli() + seconds*1000
+	db.SetExpire(key, expireAt)
+
+	db.addAof(utils.ToCmdLineWithName("SET", []byte(key), value))
+	db.addAof(utils.ToCmdLineWithName("PEXPIREAT", []byte(key), []byte(strconv.FormatInt(expireAt, 10))))
 	return reply.MakeOKReply()
 }
 
@@ -72,9 +134,9 @@ func execStrLen(db *DB, args [][]byte) resp.Reply {
 
 func init() {
 	RegisterCommand("GET", execGet, 2)
-	RegisterCommand("SET", execSet, 3)
+	RegisterCommand("SET", execSet, -3)
 	RegisterCommand("SETNX", execSetNX, 3)
 	RegisterCommand("GETSET", execGetSet, 3)
-	RegisterCommand("SETEX", execSet, 4)
+	RegisterCommand("SETEX", execSetEX, 4)
 	RegisterCommand("STRLEN", execStrLen, 2)
 }


### PR DESCRIPTION
## Summary
- add DB expiration tracking with lazy expiry and TTL clearing on writes
- implement EXPIRE/PEXPIRE/EXPIREAT/PEXPIREAT/TTL/PTTL/PERSIST and SET/SETEX TTL with AOF PEXPIREAT
- update cluster routing and README command list

## Testing
- go test ./...